### PR TITLE
victionary 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,24 +12,77 @@ An easy to use dict client for Vim.
 
 For easy installation, I highly suggest that you install a plugin manager (ie. Pathogen/Vundle/NeoBundle)
 
+* Vim 8 Native Package Manager
+```bash
+mkdir ~/.vim/pack/plugin/start/victionary
+git clone https://github.com/farconics/victionary ~/.vim/pack/plugin/start/victionary
+```
+
 * [Pathogen][1]
-	* `git clone https://github.com/farconics/victionary ~/.vim/bundle/victionary`
+```bash
+git clone https://github.com/farconics/victionary ~/.vim/bundle/victionary
+```
+* [Vim-Plug][2]
+
+1. Add `Plug 'farconics/victionary'` to your `.vimrc` file.
+2. Reload your `.vimrc`.
+3. Run `:PlugInstall`
+
+* [Vundle][3]
+
+1. Add `Plugin 'farconics/victionary'` to your `.vimrc` file.
+2. Reload your `.vimrc`.
+3. Run `:BundleInstall`
+
+* [NeoBundle][4]
+
+1. Add `NeoBundle 'farconics/victionary'` to your `.vimrc` file.
+2. Reload your `.vimrc`.
+3. Run `:NeoUpdate`
+
 
 # Configuration
 
-The plugin works out of the box, using 'dict.org' as the host and WordNet as dictionary.
-I will try to add the option to specify a host and dictionary in the future.
+The plugin works out of the box, using 'dict.org' as the host and WordNet as
+the dictionary. I will try to add the option to specify a host and dictionary
+in the future.
 
 # Usage
 
-The hotkey for triggering the plugin is:
+### Mappings
 
-	<Leader>d
+`<Plug>(victionary#word_prompt)`
+* Prompts the user for a word to search
 
-If you'd like to change the custom mapping, add this to your .vimrc:
+`<Plug>(victionary#under_cursor)`
+* Searches the word currently under the cursor
 
-	let g:victionary_mapping = 0
-	nnoremap <mapping> :call <SID>WordPrompt()<CR>
+By default, the hotkeys for triggering each mapping are:
+
+|    Hotkey   |              Mapping              |
+|:-----------:|:---------------------------------:|
+| `<Leader>d` | `<Plug>(victionary#word_prompt)`  |
+| `<Leader>D` | `<Plug>(victionary#under_cursor)` |
+
+If you'd like to disable the default mappings, add this to your `.vimrc`:
+
+```vim
+let g:victionary#map_defaults = 0
+```
+
+If you'd like to customize the mappings, add this to your `.vimrc`:
+
+```vim
+let g:victionary#map_defaults = 0
+nmap <mapping> <Plug>(victionary#word_prompt)
+nmap <mapping> <Plug>(victionary#under_cursor)
+```
+
+### Command
+
+`:Victionary`
+* Takes a word as a parameter to search
+
 
 Looking up a word will open a horizontal split at the bottom, simply press q
 to close the window.
@@ -39,3 +92,6 @@ to close the window.
 ![img](https://github.com/farconics/victionary/wiki/images/demo2.gif)
 
 [1]: https://github.com/tpope/vim-pathogen
+[2]: https://github.com/junegunn/vim-plug
+[3]: https://github.com/VundleVim/Vundle.vim
+[4]: https://github.com/Shougo/neobundle.vim

--- a/plugin/dict.rb
+++ b/plugin/dict.rb
@@ -29,7 +29,7 @@ module Dict
 
   # Default host.
   DEFAULT_HOST = "www.dict.org"
-  
+
   # Default port.
   DEFAULT_PORT = 2628
 
@@ -47,7 +47,7 @@ module Dict
   MATCH_DEFAULT = "."
   MATCH_EXACT   = "exact"
   MATCH_PREFIX  = "prefix"
-  
+
   # The various response numbers.
   RESPONSE_DATABASES_FOLLOW    = 110
   RESPONSE_STRATEGIES_FOLLOW   = 111
@@ -62,7 +62,7 @@ module Dict
   RESPONSE_NO_MATCH            = 552
   RESPONSE_NO_DATABASES        = 554
   RESPONSE_NO_STRATEGIES       = 555
-  
+
   # Get the reply code of the passed text.
   def replyCode( text, default = nil )
 
@@ -73,12 +73,12 @@ module Dict
     else
       raise DictError.new(), "Invalid reply from host \"#{text}\"."
     end
-    
+
   end
 
   # replyCode should be private.
   private :replyCode
-  
+
 end
 
 ############################################################################
@@ -94,7 +94,7 @@ class DictDefinition < Array
 
   # Mixin the Dict utility code.
   include Dict
-  
+
   # Constructor
   def initialize( details, conn )
 
@@ -113,7 +113,7 @@ class DictDefinition < Array
     end
 
   end
-  
+
   # Access to the word
   def word
     @word
@@ -142,7 +142,7 @@ class DictDefinitionList < Array
 
   # Mixin the Dict utility code.
   include Dict
-  
+
   # Constructor
   def initialize( conn )
 
@@ -156,7 +156,7 @@ class DictDefinitionList < Array
     end
 
   end
-  
+
 end
 
 ############################################################################
@@ -179,7 +179,7 @@ class DictArray < Array
     end
 
   end
-  
+
 end
 
 ############################################################################
@@ -202,7 +202,7 @@ class DictArrayItem
   def description
     @description
   end
-  
+
 end
 
 ############################################################################
@@ -252,7 +252,7 @@ class DictClient < DictBase
 
   # checkConnection should be private.
   private :checkConnection
-  
+
   # Send text to the server
   def send( text )
     checkConnection()
@@ -261,7 +261,7 @@ class DictClient < DictBase
 
   # send should be private.
   private :send
-  
+
   # Connect to the host.
   def connect
 
@@ -273,7 +273,7 @@ class DictClient < DictBase
 
       # Nope, open a connection
       @conn = TCPSocket.open( host, port )
-      
+
       # Get the banner.
       @banner = @conn.readline()
 
@@ -287,10 +287,10 @@ class DictClient < DictBase
       unless replyCode( reply = @conn.readline() ) == RESPONSE_OK
         raise DictError.new(), "Client announcement failed \"#{reply}\""
       end
-      
+
       # If we were passed a block, yield to it
       yield self if block_given?
-      
+
     end
 
   end
@@ -335,12 +335,12 @@ class DictClient < DictBase
       # Something else, throw an error.
       raise DictError.new(), reply
     end
-    
+
   end
 
   # arrayCommand is private.
   private :arrayCommand
-  
+
   # Define a word.
   def define( word, database = DB_ALL )
     arrayCommand( "define #{database} \"#{word}\"", DictDefinitionList, RESPONSE_DEFINITIONS_FOLLOW, RESPONSE_NO_MATCH )
@@ -375,7 +375,7 @@ class DictClient < DictBase
   def help
     arrayCommand( "help", DictArray, RESPONSE_HELP_FOLLOWS )
   end
-  
+
 end
 
 ############################################################################
@@ -387,7 +387,7 @@ if $0 == __FILE__
 
   # Command result
   result = 1
-  
+
   # Setup the default parameters.
   $params = {
     :host       => ENV[ "DICT_HOST" ]  || Dict::DEFAULT_HOST,
@@ -508,38 +508,37 @@ Ave, Cambridge, MA 02139, USA.
 
       # With a dict client...
       DictClient.new( $params[ :host ], $params[ :port ] ).connect() do |dc|
-        
+
         # User wants to see a list of databases?
         printList( "Databases", dc.databases ) if $params[ :dbs ]
-        
+
         # User wants to see a list of strategies?
         printList( "Strategies", dc.strategies ) if $params[ :strats ]
-        
+
         # User wants to see the server help?
         printList( "Server help", dc.help ) if $params[ :serverhelp ]
-        
+
         # User wants to see help on a database?
         printList( "Info for #{$params[ :info ]}", dc.info( $params[ :info ] ) ) if $params[ :info ]
-        
+
         # User wants to see server information?
         printList( "Server information", dc.server ) if $params[ :serverinfo ]
-        
+
         # Look up any words left on the command line.
         ARGV.each do |word|
-          
-          
+
           # Did the user require a match?
           if $params[ :match ]
-            
+
             # Yes, display matches.
             if ( matches = dc.match( word, $params[ :strategy ], $params[ :database ] ) ).empty?
               print "No matches found\n"
             else
               matches.each {|wm| print "Database: \"#{wm.name}\" Match: \"#{wm.description}\"\n" }
             end
-            
+
           else
-            
+
             # No, display definitions.
             if ( defs = dc.define( word, $params[ :database ] ) ).empty?
               print "No definitions found\n"
@@ -548,19 +547,19 @@ Ave, Cambridge, MA 02139, USA.
                 wd.each {|line| print line + "\n" }
               end
             end
-            
+
           end
-          
+
         end
-        
+
         # Disconnect.
         dc.disconnect()
-      
+
       end
 
       # If we made it this far everything should have worked.
       result = 0
-      
+
     rescue SocketError => e
       print "Error connecting to server: #{e}\n"
     rescue DictError => e
@@ -573,7 +572,7 @@ Ave, Cambridge, MA 02139, USA.
 
   # Return the result to the caller.
   exit result
-  
+
 end
 
 ### dict.rb ends here

--- a/plugin/victionary.vim
+++ b/plugin/victionary.vim
@@ -2,16 +2,15 @@
 " Vim plugin for looking up words in an online dictionary (ie. WordNet)
 " A fork of the vim-online-thesaurus plugin
 " Author:	Jose Francisco Taas
-" Version: 0.1.0
+" Version: 1.0.0
 " Credits to both Anton Beloglazov and Nick Coleman: original idea and code
 " And to Dave Pearson: RFC 2229 client for ruby
 " NOTE: This is a very hackish implementation since I didn't originally
 " plan on sharing the code. It could also be because I'm a piss-poor coder.
 " =========================================================================
-if exists("g:loaded_victionary")
+if exists("g:victionary#loaded")
 	finish
 endif
-let g:loaded_victionary = 1
 
 let s:path = expand('<sfile>:p:h')
 let s:dictpath = s:path . '/dict.rb'
@@ -50,12 +49,18 @@ function! s:WordPrompt()
 	call s:Lookup(word)
 endfunction
 
-if !exists('g:victionary_mapping')
-	let g:victionary_mapping = 1
+if !exists('g:victionary#map_defaults')
+	let g:victionary#map_defaults = 1
 endif
 
-if g:victionary_mapping
-	nnoremap <unique> <Leader>d :call <SID>WordPrompt()<CR>
+nnoremap <Plug>(victionary#word_prompt) :call <SID>WordPrompt()<Return>
+nnoremap <Plug>(victionary#under_cursor) :call <SID>Lookup('<C-r><C-w>')<Return>
+
+if g:victionary#map_defaults
+	nnoremap <unique> <Leader>d <Plug>(victionary#word_prompt)
+	nnoremap <unique> <Leader>D <Plug>(victionary#under_cursor)
 endif
 
 command! -nargs=1 Victionary :call <SID>Lookup(<f-args>)
+
+let g:victionary#loaded = 1


### PR DESCRIPTION
### New Features
`<Plug>(victionary#under_cursor)`
- define the word currently under cursor

### Changes
`<Plug>(victionary#word_prompt)`
- Renamed to provide an API for users to map

Rename public variables to use victionary namespace.
- `g:loaded_victionary` -> `g:victionary#loaded`
- `g:victionary_mapping` -> `g:victionary#map_defaults`

Strip whitespace from `dict.rb`
