### PR TITLE
victionary 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ An easy to use dict client for Vim.
 4. [Usage](#usage)
     - [Mappings](#mappings)
     - [Commands](#commands)
+    - [Variables](#variables)
 5. [Examples](#examples)
 
 </details>
@@ -134,6 +135,23 @@ nmap <mapping> <Plug>(victionary#synonym_under_cursor)
 
 Looking up a word will open a horizontal split at the bottom, simply press q
 to close the window.
+
+### Variables
+
+`g:victionary#format_results`
+
+Type: `Number`
+
+Default: `1`
+
+If this variable is set to a non-zero value, then the results are formatted to
+remove visual clutter. This includes disabling 'number', `relativenumber`,
+`listchars`, and `colorcolumn`, while enabling `cursorline` for visual
+distinction. If you like to have the results window to be unaltered, add the
+following to your `.vimrc`:
+```vim
+let g:victionary#format_results = 0
+```
 
 ## Examples
 

--- a/doc/victionary.txt
+++ b/doc/victionary.txt
@@ -1,4 +1,4 @@
-*victionary.txt*        For Vim version 8.1         Last change: 2019 January 19
+*victionary.txt*        For Vim version 8.1         Last change: 2019 January 21
 
                  _   _ _      _   _                                            ~
                 | | | (_)    | | (_)                                           ~
@@ -21,6 +21,7 @@ CONTENTS                                                   *victionary-contents*
     3. Usage............................|victionary-usage|
         3.1. Mappings...................|victionary-mappings|
         3.2. Commands...................|victionary-commands|
+        3.3. Variables..................|victionary-variables|
 
 ==============================================================================
 1. Introduction                                        *victionary-introduction*
@@ -109,5 +110,21 @@ Takes a word as a parameter to get synonyms
 Looking up a word will open a horizontal split at the bottom, simply press q
 to close the window.
 
+------------------------------------------------------------------------------
+3.3. Variables                                            *victionary-variables*
+
+g:victionary#format_results                        *g:victionary#format_results*
+
+Type: |Number|
+Default: `1`
+
+If this variable is set to a non-zero value, then the results are formatted to
+remove visual clutter. This includes disabling 'number', 'relativenumber',
+'listchars', and 'colorcolumn', while enabling 'cursorline' for visual
+distinction. If you like to have the results window to be unaltered, add the
+following to your |.vimrc|: >
+
+        let g:victionary#format_results = 0
+<
 ==============================================================================
 vim:tw=78:ts=8:ft=help:noet:nospell:expandtab

--- a/plugin/victionary.vim
+++ b/plugin/victionary.vim
@@ -2,7 +2,7 @@
 " Vim plugin for looking up words in an online dictionary (ie. WordNet)
 " A fork of the vim-online-thesaurus plugin
 " Author:	Jose Francisco Taas, Evan Quan
-" Version: 3.0.0
+" Version: 3.1.0
 " Credits to both Anton Beloglazov and Nick Coleman: original idea and code
 " And to Dave Pearson: RFC 2229 client for ruby
 " NOTE: This is a very hackish implementation since I didn't originally
@@ -18,17 +18,20 @@ let s:dictpath = s:path . '/dict.rb'
 let g:victionary#WORD_NET = "wn"
 let g:victionary#GCIDE = "gcide"
 
+if !exists("g:victionary#format_results")
+	let g:victionary#format_results = 1
+endif
+
 let s:thesaurus = "moby-thesaurus"
 
 let s:dictionary_names = {
-                       \ g:victionary#WORD_NET : "WordNet",
-                       \ g:victionary#GCIDE : "GCIDE",
-                       \ s:thesaurus : "Moby Thesaurus",
-                       \}
+                          \ g:victionary#WORD_NET : "WordNet",
+                          \ g:victionary#GCIDE    : "GCIDE",
+                          \ s:thesaurus           : "Moby Thesaurus",
+                          \}
 
 if !exists("g:victionary#dictionary")
-	let g:victionary#dictionary =  g:victionary#WORD_NET
-	" let g:victionary#dictionary =  g:victionary#GCIDE
+	let g:victionary#dictionary = g:victionary#WORD_NET
 endif
 
 function! s:GetThesaurus()
@@ -42,7 +45,7 @@ function! s:Lookup(word, dictionary)
 	1,$d
 	echo "Fetching " . a:word . " from the " . s:dictionary_names[a:dictionary] . " dictionary..."
 	exec "silent 0r !" . s:dictpath . " -d " . a:dictionary . " " . a:word
-	normal! ggiWord: 
+	normal! ggiWord:
 ruby << EOF
 	@buffer = VIM::Buffer.current
 	resizeTo = VIM::evaluate("line('$')") + 1
@@ -54,7 +57,11 @@ ruby << EOF
 	end
 	VIM.command("resize #{resizeTo - 1}")
 EOF
-	nnoremap <silent> <buffer> q :q<CR>
+	nnoremap <silent> <buffer> q :q<Return>
+	if g:victionary#format_results
+		setlocal nonumber norelativenumber showbreak="" nolist
+		setlocal cursorline colorcolumn=""
+	endif
 	setlocal nomodifiable filetype=victionary
 endfunction
 


### PR DESCRIPTION
### New features

Add `g:victionary#format_results`, which is enabled by default.

It formats the results to remove visual clutter, similar to CtrlP, NERDTree, vim-leader-guide, vim-plug, and other plugins that create temporary windows. It can be disabled if the user wants to keep their results unformatted (which is the state of the plugin before this update).