### PR TITLE
Support no `ruby` built env

### DIFF
--- a/plugin/victionary.vim
+++ b/plugin/victionary.vim
@@ -48,7 +48,7 @@ function! s:Lookup(word, dictionary)
 	normal! ggiWord:
 
 	let l:resizeTo = line('$') + 1
-	let l:l = search('2:', 'n')
+	let l:l = search('^\s*2[:.]', 'n')
 	if l:l > 0
 		let l:resizeTo = l:l
 	endif

--- a/plugin/victionary.vim
+++ b/plugin/victionary.vim
@@ -46,27 +46,15 @@ function! s:Lookup(word, dictionary)
 	echo "Fetching " . a:word . " from the " . get(s:dictionary_names, a:dictionary, a:dictionary) . " dictionary..."
 	exec "silent 0r !" . s:dictpath . " -d " . a:dictionary . " " . a:word
 	normal! ggiWord:
-	if has('ruby')
-ruby << EOF
-	@buffer = VIM::Buffer.current
-	resizeTo = VIM::evaluate("line('$')") + 1
-	for i in 1..@buffer.count
-		if @buffer[i].include? "2:"
-			resizeTo = i
-			break
-		end
-	end
-	VIM.command("resize #{resizeTo - 1}")
-EOF
-	else
-		let l:resizeTo = line('$') + 1
-		let l:l = search('2:', 'n')
-		if l:l > 0
-			let l:resizeTo = l:l
-		endif
-		exec 'resize ' . (l:resizeTo - 1)
-		unlet! l:l l:resizeTo
+
+	let l:resizeTo = line('$') + 1
+	let l:l = search('2:', 'n')
+	if l:l > 0
+		let l:resizeTo = l:l
 	endif
+	exec 'resize ' . (l:resizeTo - 1)
+	unlet! l:l l:resizeTo
+
 	nnoremap <silent> <buffer> q :q<Return>
 	if g:victionary#format_results
 		setlocal nonumber norelativenumber showbreak="" nolist

--- a/plugin/victionary.vim
+++ b/plugin/victionary.vim
@@ -46,6 +46,7 @@ function! s:Lookup(word, dictionary)
 	echo "Fetching " . a:word . " from the " . get(s:dictionary_names, a:dictionary, a:dictionary) . " dictionary..."
 	exec "silent 0r !" . s:dictpath . " -d " . a:dictionary . " " . a:word
 	normal! ggiWord:
+	if has('ruby')
 ruby << EOF
 	@buffer = VIM::Buffer.current
 	resizeTo = VIM::evaluate("line('$')") + 1
@@ -57,6 +58,15 @@ ruby << EOF
 	end
 	VIM.command("resize #{resizeTo - 1}")
 EOF
+	else
+		let l:resizeTo = line('$') + 1
+		let l:l = search('2:', 'n')
+		if l:l > 0
+			let l:resizeTo = l:l
+		endif
+		exec 'resize ' . (l:resizeTo - 1)
+		unlet! l:l l:resizeTo
+	endif
 	nnoremap <silent> <buffer> q :q<Return>
 	if g:victionary#format_results
 		setlocal nonumber norelativenumber showbreak="" nolist


### PR DESCRIPTION
It is using vim `ruby` command that requires `has('ruby')`, to resize the victionary window.
In my env, Ubuntu, vim does not have it, and it raised an error only because of this.

So, if there is no special reason to use `ruby` commands here, shouldn't you implement in vim commands?