### PR TITLE
Use existing window in the current tab

### DIFF
--- a/plugin/victionary.vim
+++ b/plugin/victionary.vim
@@ -41,8 +41,6 @@ function! s:GetThesaurus()
 endfunction
 
 function! s:Lookup(word, dictionary)
-	let l:curwin = winnr()
-
 	let l:wordwin = bufwinnr(get(s:, 'buf', -1))
 	if l:wordwin > 0
 		exec l:wordwin . ' wincmd w'
@@ -76,8 +74,7 @@ function! s:Lookup(word, dictionary)
 	endif
 	setlocal nomodifiable filetype=victionary
 
-	exec l:curwin . ' wincmd w'
-	unlet! l:curwin l:wordwin
+	unlet! l:wordwin
 endfunction
 
 function! s:WordPrompt(prompt, dictionary)

--- a/plugin/victionary.vim
+++ b/plugin/victionary.vim
@@ -41,6 +41,8 @@ function! s:GetThesaurus()
 endfunction
 
 function! s:Lookup(word, dictionary)
+	let l:curwin = winnr()
+
 	let l:wordwin = bufwinnr(get(s:, 'buf', -1))
 	if l:wordwin > 0
 		exec l:wordwin . ' wincmd w'
@@ -74,7 +76,8 @@ function! s:Lookup(word, dictionary)
 	endif
 	setlocal nomodifiable filetype=victionary
 
-	unlet! l:wordwin
+	exec l:curwin . ' wincmd w'
+	unlet! l:curwin l:wordwin
 endfunction
 
 function! s:WordPrompt(prompt, dictionary)


### PR DESCRIPTION
Now it always opens a new victionary window even if the current tab already has one.

Although, both of the old and new victionary windows are the same buffer;
after victionary command, the both window contents are refreshed to new one.
There is no need to open a new one.

Instead, use the existing victionary window in the current tab.