### PR TITLE
Log fix not to raise an error for unknown dictionary short names

### DIFF
--- a/plugin/victionary.vim
+++ b/plugin/victionary.vim
@@ -43,7 +43,7 @@ function! s:Lookup(word, dictionary)
 	setlocal noswapfile nobuflisted nospell nowrap modifiable
 	setlocal buftype=nofile bufhidden=hide
 	1,$d
-	echo "Fetching " . a:word . " from the " . s:dictionary_names[a:dictionary] . " dictionary..."
+	echo "Fetching " . a:word . " from the " . get(s:dictionary_names, a:dictionary, a:dictionary) . " dictionary..."
 	exec "silent 0r !" . s:dictpath . " -d " . a:dictionary . " " . a:word
 	normal! ggiWord:
 ruby << EOF


### PR DESCRIPTION
It being just sending queries to dict.org, other dictionaries, such as `fd-eng-jpn` (English-Japanese dic), are capable.

However, in showing message, it raises an error for unknown dictionary IDs.
This is not an essential error.

So, why don't you show dictionary ID name itself if its long name is unknown?
