### PR TITLE
Bugfix: Escape the external script `dict.rb` call command

### DIFF
--- a/plugin/victionary.vim
+++ b/plugin/victionary.vim
@@ -44,7 +44,7 @@ function! s:Lookup(word, dictionary)
 	setlocal buftype=nofile bufhidden=hide
 	1,$d
 	echo "Fetching " . a:word . " from the " . get(s:dictionary_names, a:dictionary, a:dictionary) . " dictionary..."
-	exec "silent 0r !" . s:dictpath . " -d " . a:dictionary . " " . a:word
+	exec "silent 0r !" . s:dictpath . " -d '" . substitute(a:dictionary, "'", "''", 'g') . "' '" . substitute(a:word, "'", "''", 'g') . "'"
 	normal! ggiWord:
 ruby << EOF
 	@buffer = VIM::Buffer.current


### PR DESCRIPTION
The script `dict.rb` call is handled by shell.

So, if the search word includes some special characters such as `<`, it goes bad.

Especially, `\D` (i.e. search the word under the cursor) can be involved in this:
some file types, such as Vim `help` files, include `<` and `>` in a word.

To avoid this,

* quoted dictionary name and search word by `'`
    - to help `<foobar>` or such
* replaced `'` appearance in them with `''`
    - to help `can't` or such
